### PR TITLE
AIR relay state message included

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -8,6 +8,9 @@ can:
     baudrate: 250
 
 messages:
+  - ID: 0x101
+    can_line: "can3"
+    message: "RelayState"
   - ID: 0x103
     can_line: "can3"
     message: "AMSError"

--- a/fs-common-bitproto/can.bitproto
+++ b/fs-common-bitproto/can.bitproto
@@ -11,6 +11,13 @@ message AMSError {
     bool is_under_voltage = 7; /* If the voltage of the cells is below the threshold */
 }
 
+/* Current ID: 0x101 */
+message RelayState {
+    bool AIR_POS = 6;   /* AIR Positive Relay State. 1 is closed, 0 is open */
+    bool PRECHARGE = 7;   /* Precharge Relay State. 1 is closed, 0 is open */
+    bool AIR_NEG = 8;   /* AIR Negative Relay State. 1 is closed, 0 is open */
+}
+
 /* =============== Go-Kart ================= */	
 
 // TODO below are the specific bit lengths needed on the CAN frame for each	


### PR DESCRIPTION
I would like to include a new message reporting from AMS, about AIR relay states. AIR +, AIR - and Precharge relay. It will be in CAN3, 0x101, length of 1 and in an order of AIR -, Precharge, and AIR + state from LSB. 